### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-alpine
+
+WORKDIR /app
+
+COPY tools/web.py /app/
+
+RUN pip3 install --no-cache-dir requests fake-useragent
+
+EXPOSE 5000
+
+CMD [ "python", "./web.py" ]


### PR DESCRIPTION
This PR adds a simple Dockerfile which allows users to run the web.py proxy using Docker.

Running the proxy using docker can be achieved by running the following command, only requirement is the Docker daemon.
`docker run -p 5000:5000 pbxg33k/switch-reader-proxy`

Ideally you (repo owner) should setup a seperate repo so the github account and docker account will match. Setting up automated build will automagically update the docker image whenever the github repo is updated so a `docker image pull` command will suffice for users to pull latest changes